### PR TITLE
Fixed buffer overflow

### DIFF
--- a/aes-finder.cpp
+++ b/aes-finder.cpp
@@ -961,9 +961,9 @@ static void find_keys(uint32_t pid)
         avail += read;
 
         uint32_t offset = 0;
-        if (avail >= 60)
+        if (avail >= 60*sizeof(uint32_t))
         {
-            while (offset <= avail - 60)
+            while (offset <= avail - 60*sizeof(uint32_t))
             {
                 uint8_t key[32];
                 if (int len = aes_detect_enc((const uint32_t*)&buffer[offset], key))


### PR DESCRIPTION
The ctx elements in the detection routine are 4 bytes long, but they are treated as bytes in find_key(), resulting in a buffer overflow.

(I know this is some old code, but still)
