### PR TITLE
fix data loss after memmove

### DIFF
--- a/aes-finder.cpp
+++ b/aes-finder.cpp
@@ -948,7 +948,7 @@ static void find_keys(uint32_t pid)
         uint32_t read = sizeof(buffer)-avail;
         if (read > size) read = (uint32_t)size;
 
-        read = os_process_read(region, buffer, read);
+        read = os_process_read(region, buffer+avail, read);
         if (read == 0)
         {
             avail = 0;


### PR DESCRIPTION
buffer variable is always overwriting even when remainder from previous search are there 